### PR TITLE
add [Install] section to prevent any systemd errors from happening

### DIFF
--- a/droidatoll-sysfs-torch.service
+++ b/droidatoll-sysfs-torch.service
@@ -6,3 +6,6 @@ After=org.droidian.Flashlightd.service
 Type=simple
 ExecStart=/opt/droidatoll-sysfs-torch/bin/droidatoll-sysfs-torch
 Restart=on-failure
+
+[Install]
+WantedBy=graphical.target


### PR DESCRIPTION
service is prone to failure if disabled and enabled by the user manually
